### PR TITLE
Expressibility: Infer system size

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Metrics for Variational Quantum Circuits/Parameterized Quantum Circuits/Quantum 
 
 ## Installation
 
-Simply install this package from GitHub/`master` by running
+Simply install this package from GitHub/`master` by running:
 
-`pip install https://github.com/till-m/triple_e/archive/master.zip`.
+```pip install https://github.com/till-m/triple_e/archive/master.zip```
 
 ## Usage
 This package aims to support both [Qiskit](https://qiskit.org/) and [PennyLane](https://pennylane.ai/).
@@ -27,7 +27,6 @@ def circuit_a(params):
     qml.RZ(params[0], wires=0)
     return qml.density_matrix(0)
 
-n_wires = 1
 n_params = 1
 n_shots = 1000
 
@@ -35,7 +34,7 @@ n_shots = 1000
 dev = qml.device('default.qubit', wires=1)
 qnode = qml.QNode(circuit_a, dev)
 
-expressibility(qnode, n_params, n_wires, n_shots)
+expressibility(qnode, n_params, n_shots)
 ```
 
 Qiskit:
@@ -53,11 +52,10 @@ def circuit_b(weights):
     qc.rx(weights[1], 0)
     return Statevector.from_instruction(qc)
 
-n_wires = 1
 n_params = 2
 n_shots = 1000
 
-expressibility(circuit_b, n_params, n_wires, n_shots)
+expressibility(circuit_b, n_params, n_shots)
 ```
 
 ### Entanglement Capability
@@ -73,15 +71,14 @@ def separable_circuit(params):
     qml.U3(*params[3:], wires=1)
     return qml.density_matrix([0, 1])
 
-n_wires = 2
 n_params = 6
 n_shots = 10
 
 # set up a quantum device with the appropriate amount of qubits/wires
-dev = qml.device('default.qubit', wires=n_wires)
+dev = qml.device('default.qubit', wires=2)
 qnode = qml.QNode(separable_circuit, dev)
 
-entanglement_capability(qnode, n_params, n_wires, n_shots)
+entanglement_capability(qnode, n_params, n_shots)
 ```
 
 Qiskit:
@@ -107,8 +104,8 @@ n_shots = 10
 entanglement_capability(GHZ4_circuit, n_params, n_shots)
 ```
 
-## Acknowledgements
-Expressibility and entanglement capability calculation is partially based on code by Cenk Tüysüz.
+## Credits
+Developed by Till Muser at the Trapped Ion Quantum Information Group of ETH Zürich. Expressibility and entanglement capability calculation is partially based on code by Cenk Tüysüz.
 
 
 ## References

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = triple_e
-version = 0.0.3
+version = 0.0.4
 author = Till Muser
 author_email = tmuser|at|ethz.ch
 description = Metrics for VQCs, PQCs and QNNs.

--- a/test/pennylane/test_expressibility.py
+++ b/test/pennylane/test_expressibility.py
@@ -9,7 +9,7 @@ import pytest
 def one_qubit_expr(circuit, n_params, n_shots):
     dev = qml.device('lightning.qubit', wires=1)
     qnode = qml.QNode(circuit, dev)
-    return expressibility(qnode, n_params, 1, n_shots=n_shots)
+    return expressibility(qnode, n_params, n_shots=n_shots)
 
 
 def test_expressibility_single_qubit_idle():
@@ -63,6 +63,7 @@ def test_expressibility_full_method():
     dev = qml.device('lightning.qubit', wires=1)
     qnode = qml.QNode(circuit_c, dev)
 
-    assert expressibility(qnode, 3, 1, n_shots=1000,
-                          method="pairwise") == pytest.approx(expressibility(qnode, 3, 1, n_shots=1000,
-                          method="full"), abs=0.1)
+    assert expressibility(qnode, 3, n_shots=1000,
+                          method="pairwise") == pytest.approx(expressibility(
+                              qnode, 3, 1, n_shots=1000, method="full"),
+                                                              abs=0.1)

--- a/test/qiskit/test_expressibility.py
+++ b/test/qiskit/test_expressibility.py
@@ -15,7 +15,7 @@ def test_expressibility_single_qubit_idle():
         qc.id(0)
         return Statevector.from_instruction(qc)
 
-    assert expressibility(idle_circuit, 1, 1,
+    assert expressibility(idle_circuit, 1,
                           n_shots=1000) == pytest.approx(4.30, abs=0.1)
 
 
@@ -27,8 +27,8 @@ def test_expressibility_single_qubit_a():
         qc.rz(weights[0], 0)
         return Statevector.from_instruction(qc)
 
-    assert expressibility(circuit_a, 1, 1,
-                          n_shots=1000) == pytest.approx(0.22, abs=0.1)
+    assert expressibility(circuit_a, 1, n_shots=1000) == pytest.approx(0.22,
+                                                                       abs=0.1)
 
 
 def test_expressibility_single_qubit_b():
@@ -40,8 +40,8 @@ def test_expressibility_single_qubit_b():
         qc.rx(weights[1], 0)
         return Statevector.from_instruction(qc)
 
-    assert expressibility(circuit_b, 2, 1,
-                          n_shots=1000) == pytest.approx(0.02, abs=0.1)
+    assert expressibility(circuit_b, 2, n_shots=1000) == pytest.approx(0.02,
+                                                                       abs=0.1)
 
 
 def test_expressibility_single_qubit_c():
@@ -52,8 +52,8 @@ def test_expressibility_single_qubit_c():
         qc.u(*weights, 0)
         return Statevector.from_instruction(qc)
 
-    assert expressibility(circuit_c, 3, 1,
-                          n_shots=1000) == pytest.approx(0.007, abs=0.1)
+    assert expressibility(circuit_c, 3, n_shots=1000) == pytest.approx(0.007,
+                                                                       abs=0.1)
 
 
 def test_expressibility_full_method():
@@ -64,7 +64,7 @@ def test_expressibility_full_method():
         qc.u(*weights, 0)
         return Statevector.from_instruction(qc)
 
-    assert expressibility(circuit_c, 3, 1, n_shots=1000,
+    assert expressibility(circuit_c, 3, n_shots=1000,
                           method="pairwise") == pytest.approx(expressibility(
-                              circuit_c, 3, 1, n_shots=1000, method="full"),
+                              circuit_c, 3, n_shots=1000, method="full"),
                                                               abs=0.1)


### PR DESCRIPTION
Expressibility: Infers the size of the system (i.e. `n_qubits`) from the return value of the `circuit_simulator`. As a temporary measure/for backwards compatibility, `n_qubits` is retained as an optional argument of the call signature, but if supplied a `DeprecationWarning` is raised and the value is unused internally.